### PR TITLE
Add issuer, verifier, and holder service conformance classes.

### DIFF
--- a/index.html
+++ b/index.html
@@ -600,8 +600,8 @@ well as those yet to be written.
 
      <p>
 A conforming <dfn>issuer service implementation</dfn> MUST provide the interface
-described in Section [[[#issue-credential]]] and Section [[[#update-status]]].
-Other interfaces described in Section [[[#issuing]]] MAY also be provided.
+described in Section [[[#issue-credential]]]. Other interfaces described in
+Section [[[#issuing]]] MAY also be provided.
      </p>
 
      <p>
@@ -619,6 +619,16 @@ Conformance to protocols, query languages, and data formats described in Section
 [[[#initiating-interactions]]], Section [[[#requesting-a-presentation]]],
 Section [[[#presenting]]], and Section [[[#workflows-and-exchanges]]], and
 Section MAY also be provided.
+     </p>
+
+     <p>
+A conforming <dfn>status service implementation</dfn> MUST provide the interface
+described in Section [[[#update-status]]].
+     </p>
+
+     <p>
+A conforming <dfn>workflow service implementation</dfn> MUST provide all
+interfaces Section [[[#workflows-and-exchanges]]].
      </p>
 
       <p>

--- a/index.html
+++ b/index.html
@@ -613,12 +613,12 @@ interface described in Section [[[#verify-credential]]] and Section
 
      <p>
 A conforming <dfn>holder service implementation</dfn> MUST provide the interface
-described in Section [[[#get-exchange-protocols]]], Section
-[[[#participate-in-an-exchange]]], and Section [[[#create-presentation]]].
-Conformance to protocols, query languages, and data formats described in Section
-[[[#initiating-interactions]]], Section [[[#requesting-a-presentation]]],
-Section [[[#presenting]]], and Section [[[#workflows-and-exchanges]]], and
-Section MAY also be provided.
+described in Section [[[#get-exchange-protocols]]] and Section
+[[[#participate-in-an-exchange]]]. Conformance to protocols, query languages,
+and data formats described in Section [[[#initiating-interactions]]], Section
+[[[#requesting-a-presentation]]], Section [[[#create-presentation]]], Section
+[[[#presenting]]], and Section [[[#workflows-and-exchanges]]] MAY
+also be provided.
      </p>
 
      <p>
@@ -630,6 +630,15 @@ described in Section [[[#update-status]]].
 A conforming <dfn>workflow service implementation</dfn> MUST provide all
 interfaces Section [[[#workflows-and-exchanges]]].
      </p>
+
+     <p>
+A conforming <dfn>service client implementation</dfn> MUST provide the
+means to communicate with all REQUIRED interfaces provided by the
+corresponding service implementation. That is, a
+<em>status client implementation</em> provides means to communicate
+with all mandatory interfaces exposed by a [=status service implementation=].
+     </p>
+
 
       <p>
 All implementations MAY provide functionality beyond this specification.
@@ -664,8 +673,8 @@ a path within that host (e.g.,
       <h3>Authorization</h3>
       <p>
 This API can be deployed in a variety of networking environments which might
-contain hostile actors. As a result, conforming [=VCALM servers=]
-require conforming [=VCALM clients=] to utilize secure authorization
+contain hostile actors. As a result, conforming service implementations require
+conforming [=service client implementations=] to utilize secure authorization
 technologies when performing certain types of requests. Each HTTP endpoint
 defined in this document specifies whether or not authorization is required when
 performing a request. With the exception of the class of forbidden authorization

--- a/index.html
+++ b/index.html
@@ -598,14 +598,31 @@ well as those yet to be written.
 
     <section id="conformance">
 
-      <p>
-      </p>
      <p>
-A conforming <dfn>VCALM client</dfn> is ...
+A conforming <dfn>issuer service implementation</dfn> MUST provide the interface
+described in Section [[[#issue-credential]]] and Section [[[#update-status]]].
+Other interfaces described in Section [[[#issuing]]] MAY also be provided.
+     </p>
+
+     <p>
+A conforming <dfn>verifier service implementation</dfn> MUST provide the
+interface described in Section [[[#verify-credential]]] and Section
+[[[#verify-presentation]]]. Other interfaces described in Section
+[[[#verifying]]] MAY also be provided.
+     </p>
+
+     <p>
+A conforming <dfn>holder service implementation</dfn> MUST provide the interface
+described in Section [[[#get-exchange-protocols]]], Section
+[[[#participate-in-an-exchange]]], and Section [[[#create-presentation]]].
+Conformance to protocols, query languages, and data formats described in Section
+[[[#initiating-interactions]]], Section [[[#requesting-a-presentation]]],
+Section [[[#presenting]]], and Section [[[#workflows-and-exchanges]]], and
+Section MAY also be provided.
      </p>
 
       <p>
-A conforming <dfn>VCALM server</dfn> is ...
+All implementations MAY provide functionality beyond this specification.
       </p>
 
     </section>


### PR DESCRIPTION
This PR attempts to establish the conformance classes that we want to support in the specification.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/vcalm/pull/533.html" title="Last updated on Sep 13, 2025, 6:44 PM UTC (fa14056)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/vcalm/533/6b772ac...fa14056.html" title="Last updated on Sep 13, 2025, 6:44 PM UTC (fa14056)">Diff</a>