### PR TITLE
Added yaml to support the interaction mechanism endpoints

### DIFF
--- a/oas.yaml
+++ b/oas.yaml
@@ -1232,7 +1232,11 @@ components:
       type: object
       description: Object containing the available options for continuing the current interaction.
       required:
-        oneOf: ["inviteRequest", "vcaml"]
+        oneOf: 
+          - type: string
+              description: The value MUST be <code>inviteRequest</code>.
+          - type: string
+              description: The value MUST be <code>vcaml</code>.
       properties:
         inviteRequest:
           type: string
@@ -1257,9 +1261,7 @@ components:
         url:
           type: string
           description: A URL where the recipient can continue the interaction, should they choose.
-          examples:
-            - https://website.example/checkout/8372974
-            - https://website.example/forms/7864165 
+          example: https://website.example/checkout/8372974
         purpose:
           type: string
           description: A reason for the interaction that is human readable and usable in a concent interaction with the user recieving the inviteResponse object. 

--- a/oas.yaml
+++ b/oas.yaml
@@ -772,6 +772,7 @@ paths:
           required: true
           schema:
             type: string
+            enum: ["1"]
           description: Informs a reader of the Interaction URL of the Interaction API version, and allows for quick disambiguation of the URL when scanned from a QR Code.
       requestBody:
         description: A request for the protocols object to negotiate an interaction protocol. 

--- a/oas.yaml
+++ b/oas.yaml
@@ -1238,7 +1238,7 @@ components:
           example: https://website.example/invitation/87654321/invite-request/response
         vcaml:
           type: string
-          description: A VC-API exchanges URL that will allow the initiating user of the current interaction to continue with a VC-API credential exchange.
+          description: A VC-API exchange URL that will allow the initiating user of the current interaction to continue with a VC-API credential exchange.
           example: https://vcapi.example/workflows/z1A1FjMfnG/exchanges/z19mxakBFecZ"
         otherFutureAPI:
           type: string

--- a/oas.yaml
+++ b/oas.yaml
@@ -1233,23 +1233,25 @@ components:
       description: Object containing the available options for continuing the current interaction.
       required:
         oneOf: 
-          - type: string
-              description: The value MUST be <code>inviteRequest</code>.
-          - type: string
-              description: The value MUST be <code>vcaml</code>.
+          - $ref: "#/componenets/schemas/inviteRequest"
+          - $ref: "#/componenets/schemas/vcalm"
       properties:
         inviteRequest:
-          type: string
-          description: A URL that is intended to take the initiating user of the current interaction to a website to continue the interaction beyond this API.
-          example: https://website.example/invitation/87654321/invite-request/response
-        vcapi:
-          type: string
-          description: A VC-API exchanges URL that will allow the initiating user of the current interaction to continue with a VC-API credential exchange.
-          example: https://vcapi.example/workflows/z1A1FjMfnG/exchanges/z19mxakBFecZ
+          - $ref: "#/componenets/schemas/inviteRequest"
+        vcaml:
+          - $ref: "#/componenets/schemas/vcalm"
         otherFutureAPI:
           type: string
           description: A URL that is intended to take the initiating user of the current interaction to some other, as yet to be defined, API to continue the interaction and credential exchange.
           example: https://otherFutureAPI.example/otherFutureAPIParameter/0987
+    inviteRequest:
+      type: string
+      description: A URL that is intended to take the initiating user of the current interaction to a website to continue the interaction beyond this API.
+      example: https://website.example/invitation/87654321/invite-request/response
+    vcaml:
+      type: string
+      description: A VC-API exchanges URL that will allow the initiating user of the current interaction to continue with a VC-API credential exchange.
+      example: https://vcapi.example/workflows/z1A1FjMfnG/exchanges/z19mxakBFecZ
     InviteResponse:
       type: object
       description: Object a continuation URL for an interaction, along with a purpose for a given interaction.

--- a/oas.yaml
+++ b/oas.yaml
@@ -751,12 +751,16 @@ paths:
         - Interactions
         - Credentials
         - Exchanges
+      security:
+       - networkAuth: []
+       - oAuth2: []
+       - zCap: []
       operationId: startInteraction
       description: Retrieve available interaction protocols from the interaction originator.
       x-expectedCaller: Anyone with provided URL
       parameters:
         - in: path
-          name: interactionID
+          name: interactionId
           required: true
           schema:
             oneOf: 
@@ -793,10 +797,24 @@ paths:
       summary: Provides a location for a particular invitation response to be submitted to the by the entity trying to start an interaction. When an implementer has implemented the full VCALM, it is expected that the {inviteId} parameter will be equivalent to the {exchangeId}.
       tags:
         - Interactions
+        - Invite Request
         - Exchanges
+      security:
+       - networkAuth: []
+       - oAuth2: []
+       - zCap: []
       operationId: receiveInvitationResponse
       description: Ths endpoint is one of the ones expected to be included as a fully formed URL in the protocols object returned by the /interaction/{interactionId} endpoint.
       x-expectedCaller: Whoever POSTed to the URL containing /interaction/{interactionId}
+      parameters:
+        - in: path
+          name: inviteId
+          required: true
+          schema:
+            oneOf: 
+              - type: string
+              - type: integer
+          description: The unique inviteId that the interaction requester uses to select the invite response protocol from the set of advertised options. When an implementer has implemented the full VCALM, this value will be an {exchangeId}, and that the invite-request/response endpoint lives on the Workflow Service.
       requestBody:
         description: The inviteResponse object provides a URL to continue the interaction, a purpose for the interaction, and an ID to reference the interaction by (mostly for debug purposes).
         content:
@@ -1214,16 +1232,12 @@ components:
       type: object
       description: Object containing the available options for continuing the current interaction.
       required:
-        oneOf:
-          - inviteRequest
-          - vcapi
+        oneOf: ["inviteRequest", "vcaml"]
       properties:
         inviteRequest:
           type: string
           description: A URL that is intended to take the initiating user of the current interaction to a website to continue the interaction beyond this API.
-          examples: 
-            - https://website.example/invitation/87654321/invite-request/response
-            - https://website.example/workflows/12392212/exchanges/87654321/invite-request/response
+          example: https://website.example/invitation/87654321/invite-request/response
         vcapi:
           type: string
           description: A VC-API exchanges URL that will allow the initiating user of the current interaction to continue with a VC-API credential exchange.
@@ -1249,9 +1263,7 @@ components:
         purpose:
           type: string
           description: A reason for the interaction that is human readable and usable in a concent interaction with the user recieving the inviteResponse object. 
-          examples:
-            - Checkout at ShopCo
-            - Fill out online form
+          example: "Checkout at ShopCo"
         referenceId:
           type: string
           description: An ID used to reference this particular inviteResponse, mostly for debug purposes.

--- a/oas.yaml
+++ b/oas.yaml
@@ -1248,7 +1248,7 @@ components:
       type: string
       description: A URL that is intended to take the initiating user of the current interaction to a website to continue the interaction beyond this API.
       example: https://website.example/invitation/87654321/invite-request/response
-    vcaml:
+    vcalm:
       type: string
       description: A VC-API exchanges URL that will allow the initiating user of the current interaction to continue with a VC-API credential exchange.
       example: https://vcapi.example/workflows/z1A1FjMfnG/exchanges/z19mxakBFecZ

--- a/oas.yaml
+++ b/oas.yaml
@@ -744,6 +744,70 @@ paths:
                 $ref: "#/components/schemas/CreateChallengeResponse"
         "400":
           description: Invalid or malformed input
+  /interaction/{interactionId}:
+    get:
+      summary: Retrieve available interaction protocols from the interaction originator. 
+      tags:
+        - Interactions
+        - Credentials
+        - Exchanges
+      operationId: startInteraction
+      description: Retrieve available interaction protocols from the interaction originator.
+      x-expectedCaller: Anyone with provided URL
+      parameters:
+        - in: path
+          name: interactionID
+          required: true
+          schema:
+            oneOf: 
+              - type: string
+              - type: integer
+          description: The unique interaction identifier for the current interaction. 
+        - in: query
+          name: iuv
+          required: true
+          schema:
+            type: string
+          description: Informs a reader of the Interaction URL of the Interaction API version, and allows for quick disambiguation of the URL when scanned from a QR Code.
+      requestBody:
+        description: A request for the protocols object to negotiate an interaction protocol. 
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Protocols"
+      responses:
+        "200":
+          description: The protocols object with the advertised interaction protocol options. 
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Protocols"
+        "400":
+          description: Invalid or malformed input
+        "401":
+          description: Not Authorized
+        "500":
+          description: Internal Error
+  /{invitateId}/invite-request/response:
+    post:
+      summary: Provides a location for a particular invitation response to be submitted to the by the entitiy trying to start an interaction. In the case that an implimenter has implimented the full VCALM, it is expected that the {inviteId} parameter will be equivilant to the {exchangeId}.
+      tags:
+        - Interactions
+        - Exchanges
+      operationId: receiveInvitationResponse
+      description: Ths endpoint is one of the ones expected to be included as a fully formed URL in the protocols object returned by the /interaction/{interactionId} endpoint.
+      x-expectedCaller: Whoever POSTed to the URL containing /interaction/{interactionId}
+      requestBody:
+        description: The inviteResponse object provides a URL to continue the interaction, a purpose for the interaction, and an ID to reference the interaction by (mostly for debug purposes).
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/InviteResponse"
+      responses:
+        "200":
+          description: The inviteResponse object has been injested and was understood. This does not mean an interaction will continue, only that the inviteResponse was understood.
+        "400":
+          description: Invalid or malformed input.
 components:
   securitySchemes:
     $ref: "./components/SecuritySchemes.yml#/components/securitySchemes"
@@ -1146,3 +1210,49 @@ components:
       $ref: "./components/VerifyPresentationResult.yml#/components/schemas/VerificationResult"
     CreateChallengeResponse:
       $ref: "./components/Challenge.yml#/components/schemas/CreateChallengeResult"
+    Protocols:
+      type: object
+      description: Object containing the available options for continuing the current interaction.
+      required:
+        oneOf:
+          - inviteRequest
+          - vcapi
+      properties:
+        inviteRequest:
+          type: string
+          description: A URL that is intended to take the initiating user of the current interaction to a website to continue the interaction beyond this API.
+          examples: 
+            - https://website.example/invitation/87654321/invite-request/response
+            - https://website.example/workflows/12392212/exchanges/87654321/invite-request/response
+        vcapi:
+          type: string
+          description: A VC-API exchanges URL that will allow the initiating user of the current interaction to continue with a VC-API credential exchange.
+          example: https://vcapi.example/workflows/z1A1FjMfnG/exchanges/z19mxakBFecZ
+        otherFutureAPI:
+          type: string
+          description: A URL that is intended to take the initiating user of the current interaction to some other, as yet to be defined, API to continue the interaction and credential exchange.
+          example: https://otherFutureAPI.example/otherFutureAPIParameter/0987
+    InviteResponse:
+      type: object
+      description: Object a continuation URL for an interaction, along with a purpose for a given interaction.
+      required:
+          - url
+          - purpose
+          - referenceId
+      properties:
+        url:
+          type: string
+          description: A URL where the recipient can continue the interaction, should they choose.
+          examples:
+            - https://website.example/checkout/8372974
+            - https://website.example/forms/7864165 
+        purpose:
+          type: string
+          description: A reason for the interaction that is human readable and usable in a concent interaction with the user recieving the inviteResponse object. 
+          examples:
+            - Checkout at ShopCo
+            - Fill out online form
+        referenceId:
+          type: string
+          description: An ID used to reference this particular inviteResponse, mostly for debug purposes.
+          example: 417bcaf2-14d9-11f0-99d7-9f094678517b

--- a/oas.yaml
+++ b/oas.yaml
@@ -231,7 +231,7 @@ paths:
         content:
           application/json:
             schema:
-              oneOf:
+              :
                 - type: object
                   properties:
                     verifiablePresentationRequest:
@@ -302,7 +302,7 @@ paths:
           content:
             application/json:
               schema:
-                oneOf:
+                :
                   - $ref: "./components/VerifiableCredentialResponse.yml#/components/schemas/VerifiableCredentialResponse"
         "400":
           description: Bad Request
@@ -1231,19 +1231,20 @@ components:
     Protocols:
       type: object
       description: Object containing the available options for continuing the current interaction.
-      required:
-        oneOf: 
-          - $ref: "#/componenets/schemas/inviteRequest"
-          - $ref: "#/componenets/schemas/vcalm"
+      anyOf: 
+        - $ref: "#/components/schemas/inviteRequest"
+        - $ref: "#/components/schemas/vcalm"
+        - $ref: "#/components/schemas/otherFutureAPI"
       properties:
         inviteRequest:
-          - $ref: "#/componenets/schemas/inviteRequest"
+          schema:
+            - $ref: "#/components/schemas/inviteRequest"
         vcaml:
-          - $ref: "#/componenets/schemas/vcalm"
+          schema:
+            - $ref: "#/components/schemas/vcalm"
         otherFutureAPI:
-          type: string
-          description: A URL that is intended to take the initiating user of the current interaction to some other, as yet to be defined, API to continue the interaction and credential exchange.
-          example: https://otherFutureAPI.example/otherFutureAPIParameter/0987
+        schema:
+            - $ref: "#/components/schemas/otherFutureAPI"
     inviteRequest:
       type: string
       description: A URL that is intended to take the initiating user of the current interaction to a website to continue the interaction beyond this API.
@@ -1252,6 +1253,10 @@ components:
       type: string
       description: A VC-API exchanges URL that will allow the initiating user of the current interaction to continue with a VC-API credential exchange.
       example: https://vcapi.example/workflows/z1A1FjMfnG/exchanges/z19mxakBFecZ
+    otherFutureAPI:
+      type: string
+      description: A URL that is intended to take the initiating user of the current interaction to some other, as yet to be defined, API to continue the interaction and credential exchange.
+      example: https://otherFutureAPI.example/otherFutureAPIParameter/0987
     InviteResponse:
       type: object
       description: Object a continuation URL for an interaction, along with a purpose for a given interaction.

--- a/oas.yaml
+++ b/oas.yaml
@@ -790,7 +790,7 @@ paths:
           description: Internal Error
   /{inviteId}/invite-request/response:
     post:
-      summary: Provides a location for a particular invitation response to be submitted to the by the entitiy trying to start an interaction. In the case that an implimenter has implimented the full VCALM, it is expected that the {inviteId} parameter will be equivilant to the {exchangeId}.
+      summary: Provides a location for a particular invitation response to be submitted to the by the entity trying to start an interaction. When an implementer has implemented the full VCALM, it is expected that the {inviteId} parameter will be equivalent to the {exchangeId}.
       tags:
         - Interactions
         - Exchanges

--- a/oas.yaml
+++ b/oas.yaml
@@ -795,7 +795,7 @@ paths:
           description: Internal Error
   /{inviteId}/invite-request/response:
     post:
-      summary: Provides a location for a particular invitation response to be submitted to the by the entity trying to start an interaction. When an implementer has implemented the full VCALM, it is expected that the {inviteId} parameter will be equivalent to the {exchangeId}.
+      summary: Provides a location for a particular invitation response to be submitted to the by the entity trying to start an interaction. When an implementer has implemented the full specification, it is expected that the {inviteId} parameter will be equivalent to the {exchangeId}.
       tags:
         - Interactions
         - Invite Request
@@ -815,7 +815,7 @@ paths:
             oneOf: 
               - type: string
               - type: integer
-          description: The unique inviteId that the interaction requester uses to select the invite response protocol from the set of advertised options. When an implementer has implemented the full VCALM, this value will be an {exchangeId}, and that the invite-request/response endpoint lives on the Workflow Service.
+          description: The unique inviteId that the interaction requester uses to select the invite response protocol from the set of advertised options. When an implementer has implemented the full specification, this value will be an {exchangeId}, and that the invite-request/response endpoint lives on the Workflow Service.
       requestBody:
         description: The inviteResponse object provides a URL to continue the interaction, a purpose for the interaction, and an ID to reference the interaction by (mostly for debug purposes).
         content:
@@ -1240,11 +1240,11 @@ components:
         vcaml:
           type: string
           description: A VC-API exchange URL that will allow the initiating user of the current interaction to continue with a VC-API credential exchange.
-          example: https://vcapi.example/workflows/z1A1FjMfnG/exchanges/z19mxakBFecZ"
+          example: https://vcapi.example/workflows/z1A1FjMfnG/exchanges/z19mxakBFecZ
         otherFutureAPI:
           type: string
           description: A URL that is intended to take the initiating user of the current interaction to some other, as yet to be defined, API to continue the interaction and credential exchange.
-          example: https://otherFutureAPI.example/otherFutureAPIParameter/0987
+          example: https://otherFutureAPI.example/collection/0987
       oneOf:
         - required:
           - inviteRequest
@@ -1252,7 +1252,7 @@ components:
           - vcalm
     InviteResponse:
       type: object
-      description: Object a continuation URL for an interaction, along with a purpose for a given interaction.
+      description: Object for a continuation URL for an interaction, along with a purpose for a given interaction.
       required:
           - url
           - purpose

--- a/oas.yaml
+++ b/oas.yaml
@@ -788,7 +788,7 @@ paths:
           description: Not Authorized
         "500":
           description: Internal Error
-  /{invitateId}/invite-request/response:
+  /{inviteId}/invite-request/response:
     post:
       summary: Provides a location for a particular invitation response to be submitted to the by the entitiy trying to start an interaction. In the case that an implimenter has implimented the full VCALM, it is expected that the {inviteId} parameter will be equivilant to the {exchangeId}.
       tags:

--- a/oas.yaml
+++ b/oas.yaml
@@ -231,7 +231,7 @@ paths:
         content:
           application/json:
             schema:
-              :
+              oneOf:
                 - type: object
                   properties:
                     verifiablePresentationRequest:
@@ -302,7 +302,7 @@ paths:
           content:
             application/json:
               schema:
-                :
+                oneOf:
                   - $ref: "./components/VerifiableCredentialResponse.yml#/components/schemas/VerifiableCredentialResponse"
         "400":
           description: Bad Request

--- a/oas.yaml
+++ b/oas.yaml
@@ -1231,32 +1231,24 @@ components:
     Protocols:
       type: object
       description: Object containing the available options for continuing the current interaction.
-      anyOf: 
-        - $ref: "#/components/schemas/inviteRequest"
-        - $ref: "#/components/schemas/vcalm"
-        - $ref: "#/components/schemas/otherFutureAPI"
       properties:
         inviteRequest:
-          schema:
-            - $ref: "#/components/schemas/inviteRequest"
+          type: string
+          description: A URL that is intended to take the initiating user of the current interaction to a website to continue the interaction beyond this API.
+          example: https://website.example/invitation/87654321/invite-request/response
         vcaml:
-          schema:
-            - $ref: "#/components/schemas/vcalm"
+          type: string
+          description: A VC-API exchanges URL that will allow the initiating user of the current interaction to continue with a VC-API credential exchange.
+          example: https://vcapi.example/workflows/z1A1FjMfnG/exchanges/z19mxakBFecZ"
         otherFutureAPI:
-        schema:
-            - $ref: "#/components/schemas/otherFutureAPI"
-    inviteRequest:
-      type: string
-      description: A URL that is intended to take the initiating user of the current interaction to a website to continue the interaction beyond this API.
-      example: https://website.example/invitation/87654321/invite-request/response
-    vcalm:
-      type: string
-      description: A VC-API exchanges URL that will allow the initiating user of the current interaction to continue with a VC-API credential exchange.
-      example: https://vcapi.example/workflows/z1A1FjMfnG/exchanges/z19mxakBFecZ
-    otherFutureAPI:
-      type: string
-      description: A URL that is intended to take the initiating user of the current interaction to some other, as yet to be defined, API to continue the interaction and credential exchange.
-      example: https://otherFutureAPI.example/otherFutureAPIParameter/0987
+          type: string
+          description: A URL that is intended to take the initiating user of the current interaction to some other, as yet to be defined, API to continue the interaction and credential exchange.
+          example: https://otherFutureAPI.example/otherFutureAPIParameter/0987
+      oneOf:
+        - required:
+          - inviteRequest
+        - required:
+          - vcalm
     InviteResponse:
       type: object
       description: Object a continuation URL for an interaction, along with a purpose for a given interaction.


### PR DESCRIPTION
Add two endpoints, along with their required components. These are:

- /interactions/{interactionId}
- /{inviteId}/invite-request/response

A couple of things I would like double checked due to my unfamiliarity with yaml and OAS:

1. In the component table, for the "Protocols" object, is the "otherFutureAPI" property appropriate? I believe we aren't planning on specifying a supported list of protocols, so I was trying to show that the object is extendable.
2. In the summary of the {inviteId}/invite-request/response, I tried to capture a note from @dlongley that in the case someone implements the entire VCALM we would expect inviteID to be an exchangeId. Is this the right spot for this kind of message or should it be moved elsewhere? 