### PR TITLE
Warn against putting protocol details in interaction URL.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2305,7 +2305,7 @@ https://app.example/interactions/z8n38Dp7a?iuv=1
 
         <p>
 Protocols that encode lengthy protocol-specific information into URLs suffer
-from limitations in the maximum allowable length of a URL by software libraries.
+from limitations placed by software libraries on the maximum allowable length of a URL.
 At the time of writing, the suggested URL length limit is roughly 2,000
 characters. Implementers SHOULD NOT put information that can be expressed in the
 response to a GET request for an interaction URL, defined in Section

--- a/index.html
+++ b/index.html
@@ -2302,6 +2302,16 @@ it is fetched by the receiving system. An example of such a URL is shown below:
         <pre class="example nohighlight" title="An interaction URL">
 https://app.example/interactions/z8n38Dp7a?iuv=1
         </pre>
+
+        <p>
+Protocols that encode lengthy protocol-specific information into URLs suffer
+from limitations in the maximum allowable length of a URL by software libraries.
+At the time of writing, the suggested URL length limit is roughly 2,000
+characters. Implementers SHOULD NOT put information that can be expressed in the
+response to a GET request for an interaction URL, defined in Section
+[[[#interaction-protocols-response]]], into the query parameters of the
+interaction URL.
+        </p>
       </section>
 
       <section>


### PR DESCRIPTION
This PR is an attempt to address issue #539 by warning against putting protocol details in the interaction URL.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/vcalm/pull/554.html" title="Last updated on Sep 27, 2025, 8:08 PM UTC (fcb2f84)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/vcalm/554/2a522e0...fcb2f84.html" title="Last updated on Sep 27, 2025, 8:08 PM UTC (fcb2f84)">Diff</a>